### PR TITLE
Fix GitHub Actions: Update Unity version to 6000.0.59f2

### DIFF
--- a/.github/workflows/android-debug-build.yml
+++ b/.github/workflows/android-debug-build.yml
@@ -40,7 +40,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: Android           # Android ビルド
-          unityVersion: 6000.0.48f1         # Unity バージョン指定
+          unityVersion: 6000.0.59f2         # Unity バージョン指定
 
       - name: Upload Android Build Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Update the Unity version in the Android build workflow to match the project's actual version (6000.0.59f2). This was causing build failures as the workflow was still using the old version (6000.0.48f1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)